### PR TITLE
Add doc generator and simple React frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+output/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # Codex_gen_docs
-コードのドキュメントを生成する
+
+This repository provides a simple tool to generate documentation for Python
+projects and view the result in a lightweight React front-end.
+
+## Generating documentation
+
+Use the CLI to scan a directory and write Markdown documentation to the
+`output/` folder:
+
+```bash
+python generate_docs.py path/to/project -o output
+```
+
+The script walks the given directory, creates summaries and example docstrings
+for all Python files and writes a Markdown file for each one. An `index.json`
+file is also produced so the front-end can list the generated pages.
+
+## Viewing the documentation
+
+A minimal React application is located under `frontend/`. To preview the
+documentation open a simple HTTP server in that directory:
+
+```bash
+cd frontend
+python -m http.server 8000
+```
+
+Then visit `http://localhost:8000` in your browser. The app will load the
+Markdown files from `../output/` and render them.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Generated Docs</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/marked/marked.min.js"></script>
+</head>
+<body>
+<div id="root"></div>
+<script src="index.js"></script>
+</body>
+</html>

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,0 +1,31 @@
+async function loadIndex() {
+  const response = await fetch('../output/index.json');
+  return response.json();
+}
+
+function App() {
+  const [files, setFiles] = React.useState([]);
+  const [content, setContent] = React.useState('');
+
+  React.useEffect(() => {
+    loadIndex().then(setFiles);
+  }, []);
+
+  const loadFile = async (file) => {
+    const res = await fetch('../output/' + file);
+    const text = await res.text();
+    setContent(marked.parse(text));
+  };
+
+  return React.createElement('div', null,
+    React.createElement('h1', null, 'Generated Docs'),
+    React.createElement('ul', null,
+      files.map(f => React.createElement('li', {key: f},
+        React.createElement('a', {href: '#', onClick: () => loadFile(f)}, f)))
+    ),
+    React.createElement('div', {dangerouslySetInnerHTML: {__html: content}})
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));
+

--- a/generate_docs.py
+++ b/generate_docs.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+from pathlib import Path
+import argparse
+from generator.doc_generator import generate_docs
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate Markdown docs from Python files")
+    parser.add_argument("target", type=str, help="Target directory to scan")
+    parser.add_argument("--output", "-o", default="output", help="Output directory")
+    args = parser.parse_args()
+
+    target = Path(args.target)
+    output = Path(args.output)
+    generate_docs(target, output)
+    print(f"Documentation written to {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/generator/doc_generator.py
+++ b/generator/doc_generator.py
@@ -1,0 +1,77 @@
+import os
+import ast
+import json
+from pathlib import Path
+from typing import List
+
+try:
+    import openai
+except ImportError:  # pragma: no cover - openai optional
+    openai = None
+
+
+def scan_python_files(directory: Path) -> List[Path]:
+    """Recursively gather all Python files under *directory*."""
+    return [p for p in directory.rglob('*.py') if p.is_file()]
+
+
+def summarize_file(path: Path) -> str:
+    """Return a short summary of a Python file using OpenAI if available."""
+    code = path.read_text()
+    if openai and os.environ.get('OPENAI_API_KEY'):
+        prompt = f"Summarize the following Python code:\n\n{code}"
+        resp = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return resp.choices[0].message.content.strip()
+    # Fallback simple summary
+    return f"Auto generated summary for {path.name}."
+
+
+def generate_docstring(node: ast.AST) -> str:
+    """Create a Google style docstring for *node*."""
+    if isinstance(node, ast.FunctionDef):
+        args = [a.arg for a in node.args.args]
+        params = "\n".join(f"    {a}: TODO" for a in args)
+        return f'"""TODO: Describe {node.name}.\n\nArgs:\n{params}\n"""'
+    if isinstance(node, ast.ClassDef):
+        return '"""TODO: Describe class."""'
+    return '"""TODO"""'
+
+
+def process_file(path: Path) -> str:
+    """Generate documentation for a single Python file."""
+    tree = ast.parse(path.read_text())
+    parts = [f"# Documentation for {path.name}"]
+    parts.append("## Summary")
+    parts.append(summarize_file(path))
+
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            parts.append(f"### {node.name}")
+            docstring = generate_docstring(node)
+            parts.append('```python')
+            parts.append(ast.get_source_segment(path.read_text(), node) or '')
+            parts.append('```')
+            parts.append('Docstring:')
+            parts.append('```python')
+            parts.append(docstring)
+            parts.append('```')
+
+    return "\n".join(parts)
+
+
+def generate_docs(target: Path, output_dir: Path) -> None:
+    """Generate documentation for all Python files under *target*."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    files = scan_python_files(target)
+    written = []
+    for py_file in files:
+        doc = process_file(py_file)
+        out_file = output_dir / f"{py_file.stem}.md"
+        out_file.write_text(doc)
+        written.append(out_file.name)
+    # Write index for front-end to load
+    index_file = output_dir / "index.json"
+    index_file.write_text(json.dumps(written))


### PR DESCRIPTION
## Summary
- create `generator` package with `doc_generator.py`
- add command line tool `generate_docs.py`
- add minimal React app in `frontend/`
- document usage in `README.md`
- ignore generated output

## Testing
- `python generate_docs.py . -o output`
- `python -m http.server --directory frontend 8000` (terminated after launch)

------
https://chatgpt.com/codex/tasks/task_e_688bdbb94c7c832ba13129367bb629a7